### PR TITLE
added signed wire message

### DIFF
--- a/crates/sim2h/Cargo.toml
+++ b/crates/sim2h/Cargo.toml
@@ -17,6 +17,7 @@ holochain_persistence_api = "=0.0.8"
 holochain_json_api = "=0.0.17"
 detach = "=0.0.13"
 lib3h = { git = "https://github.com/holochain/lib3h", branch = "transport-disconnect" }
+lib3h_sodium = { git = "https://github.com/holochain/lib3h", branch = "transport-disconnect" }
 lib3h_protocol = { git = "https://github.com/holochain/lib3h", branch = "transport-disconnect" }
 lib3h_zombie_actor = { git = "https://github.com/holochain/lib3h", branch = "transport-disconnect" }
 holochain_tracing = "=0.0.1"
@@ -33,4 +34,5 @@ parking_lot = "=0.8.0"
 serde = "=1.0.89"
 serde_derive = "=1.0.89"
 serde_json = "=1.0.39"
-rand = "0.7.2"
+rand = "=0.7.2"
+base64 = "=0.10.1"

--- a/crates/sim2h/src/crypto.rs
+++ b/crates/sim2h/src/crypto.rs
@@ -8,8 +8,8 @@ use hcid::*;
 use holochain_core_types::{
     agent::Base32,
     error::{HcResult, HolochainError},
-    signature::Provenance,
 };
+pub use holochain_core_types::signature::Provenance;
 use holochain_persistence_api::cas::content::Address;
 use lib3h_protocol::data_types::Opaque;
 use lib3h_sodium::{secbuf::SecBuf, sign};

--- a/crates/sim2h/src/crypto.rs
+++ b/crates/sim2h/src/crypto.rs
@@ -1,0 +1,211 @@
+//! copied from holochain_rust::dpki::utils for sim2h server
+
+use crate::{
+    error::{Sim2hError, Sim2hResult},
+    wire_message::WireMessage,
+};
+use hcid::*;
+use holochain_core_types::{
+    agent::Base32,
+    error::{HcResult, HolochainError},
+    signature::Provenance,
+};
+use holochain_persistence_api::cas::content::Address;
+use lib3h_protocol::data_types::Opaque;
+use lib3h_sodium::{secbuf::SecBuf, sign};
+
+use std::convert::TryFrom;
+
+#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+pub struct SignedWireMessage {
+    pub provenance: Provenance,
+    pub payload: Opaque,
+}
+
+impl SignedWireMessage {
+    pub fn new(
+        mut secret_key: &mut SecBuf,
+        agent_id: Address,
+        message: WireMessage,
+    ) -> Sim2hResult<Self> {
+        let payload: Opaque = message.into();
+        let mut message_buf = SecBuf::with_insecure(payload.len());
+        message_buf
+            .write(0, &payload)
+            .expect("SecBuf must be writeable");
+
+        let mut signature_buf = SecBuf::with_insecure(SIGNATURE_SIZE);
+        lib3h_sodium::sign::sign(&mut message_buf, &mut secret_key, &mut signature_buf).unwrap();
+
+        let reader = signature_buf.read_lock();
+        let signature = base64::encode(&**reader).into();
+        let provenance = Provenance::new(agent_id, signature);
+        Ok(SignedWireMessage {
+            provenance,
+            payload,
+        })
+    }
+
+    pub fn verify(&self) -> HcResult<bool> {
+        let signature_string: String = self.provenance.signature().into();
+        let signature_bytes: Vec<u8> = base64::decode(&signature_string).map_err(|_| {
+            HolochainError::ErrorGeneric("Signature syntactically invalid".to_string())
+        })?;
+        let mut signature_buf = SecBuf::with_insecure(signature_bytes.len());
+        signature_buf
+            .write(0, signature_bytes.as_slice())
+            .expect("SecBuf must be writeable");
+
+        let mut message_buf = SecBuf::with_insecure(self.payload.len());
+        message_buf
+            .write(0, &self.payload)
+            .expect("SecBuf must be writeable");
+        verify_bufs(
+            self.provenance.source().to_string(),
+            &mut message_buf,
+            &mut signature_buf,
+        )
+    }
+}
+
+impl From<SignedWireMessage> for Opaque {
+    fn from(message: SignedWireMessage) -> Opaque {
+        serde_json::to_string(&message)
+            .expect("wiremessage should serialize")
+            .into()
+    }
+}
+
+impl TryFrom<Opaque> for SignedWireMessage {
+    type Error = Sim2hError;
+    fn try_from(message: Opaque) -> Result<Self, Self::Error> {
+        Ok(serde_json::from_str(&String::from_utf8_lossy(&message))
+            .map_err(|e| format!("{:?}", e))?)
+    }
+}
+
+pub const SEED_SIZE: usize = 32;
+#[allow(dead_code)]
+pub(crate) const SIGNATURE_SIZE: usize = 64;
+
+lazy_static! {
+    pub static ref CODEC_HCS0: hcid::HcidEncoding =
+        hcid::HcidEncoding::with_kind("hcs0").expect("HCID failed miserably with hcs0.");
+    pub static ref CODEC_HCK0: hcid::HcidEncoding =
+        hcid::HcidEncoding::with_kind("hck0").expect("HCID failed miserably with_hck0.");
+}
+
+/// Decode an HCID-encoded key into a SecBuf
+/// @param {Base32} pub_key_b32 - Public signing key to decode
+/// @param {HcidEncoding} codec - The configured HCID decoder to use
+/// @return {SecBuf} Resulting decoded key
+pub(crate) fn decode_pub_key(pub_key_b32: Base32, codec: &HcidEncoding) -> HcResult<SecBuf> {
+    // Decode Base32 public key
+    let pub_key = codec.decode(&pub_key_b32)?;
+    // convert to SecBuf
+    let mut pub_key_sec = SecBuf::with_insecure(sign::PUBLICKEYBYTES);
+    pub_key_sec
+        .from_array(&pub_key)
+        .map_err(|e| HolochainError::new(&format!("{:?}", e)))?;
+    // Done
+    Ok(pub_key_sec)
+}
+
+/// Encode with HCID a public key given as a SecBuf
+/// @param {SecBuf} pub_key_sec - Public signing key to encode
+/// @param {HcidEncoding} codec - The configured HCID encoder to use
+/// @return {Base32} Resulting HCID encoded key
+#[allow(dead_code)] //used in test only
+pub(crate) fn encode_pub_key(pub_key_sec: &mut SecBuf, codec: &HcidEncoding) -> HcResult<Base32> {
+    let locker = pub_key_sec.read_lock();
+    Ok(codec.encode(&locker[0..SEED_SIZE])?)
+}
+
+/// Verify data that was signed
+/// @param {Base32} pub_sign_key_b32 - Public signing key to verify with
+/// @param {SecBuf} data - Data buffer to verify
+/// @param {SecBuf} signature - Candidate signature for that data buffer
+/// @return true if verification succeeded
+pub fn verify_bufs(
+    pub_sign_key_b32: Base32,
+    data: &mut SecBuf,
+    signature: &mut SecBuf,
+) -> HcResult<bool> {
+    let mut pub_key = decode_pub_key(pub_sign_key_b32, &CODEC_HCS0)?;
+    Ok(lib3h_sodium::sign::verify(signature, data, &mut pub_key))
+}
+
+/// returns a random buf
+pub fn generate_random_buf(size: usize) -> SecBuf {
+    let mut seed = SecBuf::with_insecure(size);
+    seed.randomize();
+    seed
+}
+
+/// returns a random seed buf
+pub fn generate_random_seed_buf() -> SecBuf {
+    generate_random_buf(SEED_SIZE)
+}
+
+#[cfg(test)]
+pub mod tests {
+    use super::*;
+    use lib3h_sodium::{secbuf::SecBuf, sign};
+    #[test]
+    fn it_should_hcid_roundtrip() {
+        let mut pub_sec_buf = SecBuf::with_insecure(sign::PUBLICKEYBYTES);
+        pub_sec_buf.randomize();
+
+        let codec = HcidEncoding::with_kind("hcs0").expect("HCID failed miserably with_hcs0");
+        let pub_key_b32 = encode_pub_key(&mut pub_sec_buf, &codec).unwrap();
+
+        let mut roundtrip = decode_pub_key(pub_key_b32, &codec)
+            .expect("Public key decoding failed. Key was not properly encoded.");
+
+        assert!(pub_sec_buf.compare(&mut roundtrip) == 0);
+    }
+
+    pub fn make_test_agent_with_private_key(seed: &str) -> (Address, SecBuf) {
+        let codec = HcidEncoding::with_kind("hcs0").expect("HCID failed miserably with_hcs0");
+        let mut seed_buf = SecBuf::with_insecure(SEED_SIZE);
+        seed_buf
+            .write(0, seed.as_bytes())
+            .expect("SecBuf must be writeable");
+        let mut public_key = SecBuf::with_insecure(sign::PUBLICKEYBYTES);
+        let mut secret_key = SecBuf::with_secure(sign::SECRETKEYBYTES);
+        lib3h_sodium::sign::seed_keypair(&mut public_key, &mut secret_key, &mut seed_buf).unwrap();
+        let pub_key_b32 = encode_pub_key(&mut public_key, &codec).unwrap();
+        (pub_key_b32.into(), secret_key)
+    }
+
+    #[test]
+    fn it_should_verify_signed_wire_message() {
+        let (agent_id, mut secret_key) = make_test_agent_with_private_key("test_agent");
+
+        let message = WireMessage::Err("fake_error".into());
+
+        let signed_message =
+            SignedWireMessage::new(&mut secret_key, agent_id, message).expect("should construct");
+        assert_eq!(Ok(true), signed_message.verify());
+    }
+
+    #[test]
+    fn it_should_verify_bufs() {
+        let codec = HcidEncoding::with_kind("hcs0").expect("HCID failed miserably with_hcs0");
+        // Create random seed
+        let mut seed = SecBuf::with_insecure(SEED_SIZE);
+        seed.randomize();
+        // Create keys
+        let mut public_key = SecBuf::with_insecure(sign::PUBLICKEYBYTES);
+        let mut secret_key = SecBuf::with_secure(sign::SECRETKEYBYTES);
+        lib3h_sodium::sign::seed_keypair(&mut public_key, &mut secret_key, &mut seed).unwrap();
+        let pub_key_b32 = encode_pub_key(&mut public_key, &codec).unwrap();
+        // Create signing buffers
+        let mut message = SecBuf::with_insecure(42);
+        message.randomize();
+        let mut signature = SecBuf::with_insecure(SIGNATURE_SIZE);
+        lib3h_sodium::sign::sign(&mut message, &mut secret_key, &mut signature).unwrap();
+        let res = verify_bufs(pub_key_b32, &mut message, &mut signature);
+        assert!(res.unwrap());
+    }
+}

--- a/crates/sim2h/src/crypto.rs
+++ b/crates/sim2h/src/crypto.rs
@@ -23,7 +23,14 @@ pub struct SignedWireMessage {
 }
 
 impl SignedWireMessage {
-    pub fn new(
+    pub fn new(message: WireMessage, provenance: Provenance) -> Self {
+        SignedWireMessage {
+            provenance,
+            payload: message.into(),
+        }
+    }
+
+    pub fn new_with_key(
         mut secret_key: &mut SecBuf,
         agent_id: Address,
         message: WireMessage,
@@ -185,7 +192,7 @@ pub mod tests {
         let message = WireMessage::Err("fake_error".into());
 
         let signed_message =
-            SignedWireMessage::new(&mut secret_key, agent_id, message).expect("should construct");
+            SignedWireMessage::new_with_key(&mut secret_key, agent_id, message).expect("should construct");
         assert_eq!(Ok(true), signed_message.verify());
     }
 

--- a/crates/sim2h/src/error.rs
+++ b/crates/sim2h/src/error.rs
@@ -27,3 +27,4 @@ impl fmt::Display for Sim2hError {
 pub type Sim2hResult<T> = result::Result<T, Sim2hError>;
 pub const SPACE_MISMATCH_ERR_STR: &str = "space/agent id mismatch";
 pub const VERIFY_FAILED_ERR_STR: &str = "message signature failed verify";
+pub const SIGNER_MISMATCH_ERR_STR: &str = "message signer does not match content";

--- a/crates/sim2h/src/error.rs
+++ b/crates/sim2h/src/error.rs
@@ -26,3 +26,4 @@ impl fmt::Display for Sim2hError {
 }
 pub type Sim2hResult<T> = result::Result<T, Sim2hError>;
 pub const SPACE_MISMATCH_ERR_STR: &str = "space/agent id mismatch";
+pub const VERIFY_FAILED_ERR_STR: &str = "message signature failed verify";

--- a/crates/sim2h/src/lib.rs
+++ b/crates/sim2h/src/lib.rs
@@ -768,7 +768,7 @@ pub mod tests {
         data: &SpaceData,
         message: WireMessage,
     ) -> SignedWireMessage {
-        SignedWireMessage::new(secret_key, data.clone().agent_id, message)
+        SignedWireMessage::new_with_key(secret_key, data.clone().agent_id, message)
             .expect("can make signed message")
     }
 

--- a/crates/sim2h/src/lib.rs
+++ b/crates/sim2h/src/lib.rs
@@ -5,13 +5,16 @@ extern crate log;
 extern crate detach;
 #[macro_use]
 extern crate serde;
+#[macro_use]
+extern crate lazy_static;
 
 pub mod cache;
 pub mod connection_state;
+pub mod crypto;
 pub mod error;
 pub mod wire_message;
 
-use crate::error::*;
+use crate::{crypto::*, error::*};
 use cache::*;
 use connection_state::*;
 pub use wire_message::{WireError, WireMessage};
@@ -155,8 +158,7 @@ impl Sim2h {
 
     // removes an agent from a space
     fn leave(&self, uri: &Lib3hUri, data: &SpaceData) -> Sim2hResult<()> {
-        if let Some(ConnectionState::Joined(space_address, agent_id)) = self.get_connection(uri)
-        {
+        if let Some(ConnectionState::Joined(space_address, agent_id)) = self.get_connection(uri) {
             if (data.agent_id != agent_id) || (data.space_address != space_address) {
                 Err(SPACE_MISMATCH_ERR_STR.into())
             } else {
@@ -255,6 +257,19 @@ impl Sim2h {
         }
     }
 
+    fn verify_payload(payload: Opaque) -> Sim2hResult<(AgentId, WireMessage)> {
+        let signed_message = SignedWireMessage::try_from(payload)?;
+        let result = signed_message.verify().unwrap();
+        if !result {
+            return Err(VERIFY_FAILED_ERR_STR.into());
+        }
+        let wire_message = WireMessage::try_from(signed_message.payload)?;
+        Ok((
+            Address::from(signed_message.provenance.source()),
+            wire_message,
+        ))
+    }
+
     // process transport and  incoming messages from it
     pub fn process(&mut self) -> Sim2hResult<()> {
         self.num_ticks += 1;
@@ -270,17 +285,16 @@ impl Sim2h {
                 .expect("GhostMessage must have a message")
             {
                 RequestToParent::ReceivedData { uri, payload } => {
-                    match WireMessage::try_from(&payload) {
-                        Ok(wire_message) =>
+                    match Sim2h::verify_payload(payload.clone()) {
+                        Ok((_source, wire_message)) => {
                             if let Err(error) = self.handle_message(&uri, wire_message) {
                                 error!("Error handling message: {:?}", error);
-                            },
-                        Err(error) =>
-                            error!(
-                                "Could not deserialize received payload into WireMessage!\nError: {:?}\nPayload was: {:?}",
-                                error,
-                                payload
-                            )
+                            }
+                        }
+                        Err(error) => error!(
+                            "Could not verify payload!\nError: {:?}\nPayload was: {:?}",
+                            error, payload
+                        ),
                     }
                 }
                 RequestToParent::IncomingConnection { uri } => {
@@ -553,17 +567,18 @@ impl Sim2h {
                 },
             ));
             // 3. Send store message to everybody in this space
-            if let Err(e) = self.broadcast(
-                space_address.clone(),
-                &store_message,
-                    Some(&provider),
-            ) {
+            if let Err(e) = self.broadcast(space_address.clone(), &store_message, Some(&provider)) {
                 error!("Error during broadcast: {:?}", e);
             }
         }
     }
 
-    fn broadcast(&mut self, space: SpaceHash, msg: &WireMessage, except: Option<&AgentId>) -> Sim2hResult<()> {
+    fn broadcast(
+        &mut self,
+        space: SpaceHash,
+        msg: &WireMessage,
+        except: Option<&AgentId>,
+    ) -> Sim2hResult<()> {
         debug!("Broadcast in space: {:?}", space);
         let all_uris = self
             .spaces
@@ -573,7 +588,7 @@ impl Sim2h {
             .all_agents()
             .clone()
             .into_iter()
-            .filter(|(a,_)| {
+            .filter(|(a, _)| {
                 if let Some(exception) = except {
                     *a != *exception
                 } else {
@@ -617,10 +632,12 @@ impl Sim2h {
 #[cfg(test)]
 pub mod tests {
     use super::*;
+    use crate::crypto::tests::make_test_agent_with_private_key;
     use lib3h::transport::memory_mock::{
         ghost_transport_memory::*, memory_server::get_memory_verse,
     };
     use lib3h_protocol::data_types::*;
+    use lib3h_sodium::secbuf::SecBuf;
 
     // for this to actually show log entries you also have to run the tests like this:
     // RUST_LOG=lib3h=debug cargo test -- --nocapture
@@ -639,24 +656,39 @@ pub mod tests {
             .try_init();
     }
 
-    fn make_test_agent() -> AgentId {
-        "fake_agent_id".into()
+    const TEST_AGENT_NAME: &str = "fake_agent_id";
+
+    fn make_test_agent() -> (SpaceData, SecBuf) {
+        make_test_space_data_with_agent(TEST_AGENT_NAME)
     }
 
     fn make_test_space_data() -> SpaceData {
-        SpaceData {
-            request_id: "".into(),
-            space_address: "fake_space_address".into(),
-            agent_id: make_test_agent(),
-        }
+        let (space_data, _secret_key) = make_test_space_data_with_key();
+        space_data
     }
 
-    fn make_test_space_data_with_agent(agent_id: AgentId) -> SpaceData {
-        SpaceData {
-            request_id: "".into(),
-            space_address: "fake_space_address".into(),
-            agent_id,
-        }
+    fn make_test_space_data_with_key() -> (SpaceData, SecBuf) {
+        let (agent_id, secret_key) = make_test_agent_with_private_key(TEST_AGENT_NAME);
+        (
+            SpaceData {
+                request_id: "".into(),
+                space_address: "fake_space_address".into(),
+                agent_id: agent_id,
+            },
+            secret_key,
+        )
+    }
+
+    fn make_test_space_data_with_agent(agent_name: &str) -> (SpaceData, SecBuf) {
+        let (agent_id, secret_key) = make_test_agent_with_private_key(agent_name);
+        (
+            SpaceData {
+                request_id: "".into(),
+                space_address: "fake_space_address".into(),
+                agent_id,
+            },
+            secret_key,
+        )
     }
 
     fn make_test_join_message() -> WireMessage {
@@ -682,7 +714,9 @@ pub mod tests {
     }
 
     fn make_test_dm_data() -> DirectMessageData {
-        make_test_dm_data_with(make_test_agent(), "fake_to_agent_id".into(), "foo")
+        let from_space_data = make_test_space_data();
+        let (to_space_data, _) = make_test_space_data_with_agent("to_agent_id");
+        make_test_dm_data_with(from_space_data.agent_id, to_space_data.agent_id, "foo")
     }
 
     fn make_test_dm_message() -> WireMessage {
@@ -712,6 +746,15 @@ pub mod tests {
         let transport_id = "test_transport".into();
         let transport = Box::new(GhostTransportMemory::new(transport_id, netname));
         Sim2h::new(transport, Lib3hUri::with_undefined())
+    }
+
+    fn make_signed(
+        secret_key: &mut SecBuf,
+        data: &SpaceData,
+        message: WireMessage,
+    ) -> SignedWireMessage {
+        SignedWireMessage::new(secret_key, data.clone().agent_id, message)
+            .expect("can make signed message")
     }
 
     #[test]
@@ -776,7 +819,10 @@ pub mod tests {
         );
         let result = sim2h.get_connection(&uri).clone();
         assert_eq!(
-            "Some(Joined(SpaceHash(HashString(\"fake_space_address\")), HashString(\"fake_agent_id\")))",
+            format!(
+                "Some(Joined(SpaceHash(HashString(\"fake_space_address\")), HashString(\"{}\")))",
+                data.agent_id
+            ),
             format!("{:?}", result)
         );
     }
@@ -802,13 +848,14 @@ pub mod tests {
 
         let _result = sim2h.join(&uri, &data);
 
+        let orig_agent = data.agent_id.clone();
         // a leave on behalf of someone else should fail
         data.agent_id = "someone_else_agent_id".into();
         let result = sim2h.leave(&uri, &data);
         assert_eq!(result, Err(SPACE_MISMATCH_ERR_STR.into()));
 
         // a valid leave should work
-        data.agent_id = make_test_agent();
+        data.agent_id = orig_agent;
         let result = sim2h.leave(&uri, &data);
         assert_eq!(result, Ok(()));
         let result = sim2h.get_connection(&uri).clone();
@@ -849,20 +896,20 @@ pub mod tests {
         let result =
             sim2h.prepare_proxy(&uri, &data.space_address, &data.agent_id, message.clone());
         assert_eq!(
-            Err("unvalidated proxy agent fake_to_agent_id".into()),
+            Err("unvalidated proxy agent HcScixBBK8UOmkf4uvs4AI8974NEQtTzgtT7SstuVrvnizo6uWuPTpRVbiexarz".into()),
             result,
         );
 
         // proxy a dm message
         // first we have to setup the to agent in the space
-        let to_agent_data = make_test_space_data_with_agent("fake_to_agent_id".into());
+        let (to_agent_data, _key) = make_test_space_data_with_agent("to_agent_id");
         let to_uri = Lib3hUri::with_memory("addr_2");
         let _ = sim2h.handle_incoming_connect(to_uri.clone());
         let _ = sim2h.join(&to_uri, &to_agent_data);
 
         let result = sim2h.prepare_proxy(&uri, &data.space_address, &data.agent_id, message);
         assert_eq!(
-            "Ok(Some((true, Lib3hUri(\"mem://addr_2/\"), Lib3hToClient(HandleSendDirectMessage(DirectMessageData { space_address: SpaceHash(HashString(\"fake_space_address\")), request_id: \"\", to_agent_id: HashString(\"fake_to_agent_id\"), from_agent_id: HashString(\"fake_agent_id\"), content: \"foo\" })))))",
+            "Ok(Some((true, Lib3hUri(\"mem://addr_2/\"), Lib3hToClient(HandleSendDirectMessage(DirectMessageData { space_address: SpaceHash(HashString(\"fake_space_address\")), request_id: \"\", to_agent_id: HashString(\"HcScixBBK8UOmkf4uvs4AI8974NEQtTzgtT7SstuVrvnizo6uWuPTpRVbiexarz\"), from_agent_id: HashString(\"HcSCinKU7Nqnf8n4ixOaaHzxdwg8x94t67rESVyCR9yo8csrQRcZGXT6q4ahmwr\"), content: \"foo\" })))))",
             format!("{:?}", result)
         );
 
@@ -871,7 +918,7 @@ pub mod tests {
         let message = make_test_dm_message_response_with(make_test_dm_data());
         let result = sim2h.prepare_proxy(&uri, &data.space_address, &data.agent_id, message);
         assert_eq!(
-            "Ok(Some((true, Lib3hUri(\"mem://addr_2/\"), Lib3hToClient(SendDirectMessageResult(DirectMessageData { space_address: SpaceHash(HashString(\"fake_space_address\")), request_id: \"\", to_agent_id: HashString(\"fake_to_agent_id\"), from_agent_id: HashString(\"fake_agent_id\"), content: \"foo\" })))))",
+            "Ok(Some((true, Lib3hUri(\"mem://addr_2/\"), Lib3hToClient(SendDirectMessageResult(DirectMessageData { space_address: SpaceHash(HashString(\"fake_space_address\")), request_id: \"\", to_agent_id: HashString(\"HcScixBBK8UOmkf4uvs4AI8974NEQtTzgtT7SstuVrvnizo6uWuPTpRVbiexarz\"), from_agent_id: HashString(\"HcSCinKU7Nqnf8n4ixOaaHzxdwg8x94t67rESVyCR9yo8csrQRcZGXT6q4ahmwr\"), content: \"foo\" })))))",
                 format!("{:?}", result)
         );
 
@@ -892,6 +939,7 @@ pub mod tests {
             verse.get_network(netname)
         };
         let uri = network.lock().unwrap().bind();
+        let (space_data, _key) = make_test_agent();
 
         // a message from an unconnected agent should return an error
         let result = sim2h.handle_message(&uri, make_test_err_message());
@@ -911,7 +959,10 @@ pub mod tests {
         assert_eq!(result, Ok(()));
         let result = sim2h.get_connection(&uri).clone();
         assert_eq!(
-            "Some(Joined(SpaceHash(HashString(\"fake_space_address\")), HashString(\"fake_agent_id\")))",
+            format!(
+                "Some(Joined(SpaceHash(HashString(\"fake_space_address\")), HashString(\"{}\")))",
+                space_data.agent_id
+            ),
             format!("{:?}", result)
         );
 
@@ -919,7 +970,7 @@ pub mod tests {
         // first we have to setup the to agent on the in-memory-network and in the space
         let to_uri = network.lock().unwrap().bind();
         let _ = sim2h.handle_incoming_connect(to_uri.clone());
-        let to_agent_data = make_test_space_data_with_agent("fake_to_agent_id".into());
+        let (to_agent_data, _key) = make_test_space_data_with_agent("to_agent_id");
         let _ = sim2h.join(&to_uri, &to_agent_data);
 
         // then we can make a message and handle it.
@@ -938,7 +989,7 @@ pub mod tests {
             assert!(did_work);
             let dm = &events[3];
             assert_eq!(
-                "ReceivedData(Lib3hUri(\"mem://addr_3/\"), \"{\\\"Lib3hToClient\\\":{\\\"HandleSendDirectMessage\\\":{\\\"space_address\\\":\\\"fake_space_address\\\",\\\"request_id\\\":\\\"\\\",\\\"to_agent_id\\\":\\\"fake_to_agent_id\\\",\\\"from_agent_id\\\":\\\"fake_agent_id\\\",\\\"content\\\":\\\"Zm9v\\\"}}}\")",
+                "ReceivedData(Lib3hUri(\"mem://addr_3/\"), \"{\\\"Lib3hToClient\\\":{\\\"HandleSendDirectMessage\\\":{\\\"space_address\\\":\\\"fake_space_address\\\",\\\"request_id\\\":\\\"\\\",\\\"to_agent_id\\\":\\\"HcScixBBK8UOmkf4uvs4AI8974NEQtTzgtT7SstuVrvnizo6uWuPTpRVbiexarz\\\",\\\"from_agent_id\\\":\\\"HcSCinKU7Nqnf8n4ixOaaHzxdwg8x94t67rESVyCR9yo8csrQRcZGXT6q4ahmwr\\\",\\\"content\\\":\\\"Zm9v\\\"}}}\")",
                 format!("{:?}", dm))
         } else {
             assert!(false)
@@ -950,7 +1001,7 @@ pub mod tests {
         netname: &str,
         sim2h_uri: &Lib3hUri,
         agent_name: &str,
-    ) -> (Lib3hUri, SpaceData) {
+    ) -> (SecBuf, Lib3hUri, SpaceData) {
         let network = {
             let mut verse = get_memory_verse();
             verse.get_network(netname)
@@ -958,18 +1009,19 @@ pub mod tests {
         let agent_uri = network.lock().unwrap().bind();
 
         // connect to sim2h with join messages
-        let space_data = make_test_space_data_with_agent(agent_name.into());
-        let join: Opaque = make_test_join_message_with_space_data(space_data.clone()).into();
+        let (space_data, mut secret_key) = make_test_space_data_with_agent(agent_name);
+        let join = make_test_join_message_with_space_data(space_data.clone());
+        let signed_join: Opaque = make_signed(&mut secret_key, &space_data, join).into();
         {
             let mut net = network.lock().unwrap();
             let server = net
                 .get_server(sim2h_uri)
                 .expect("there should be a server for to_uri");
             server.request_connect(&agent_uri).expect("can connect");
-            let result = server.post(&agent_uri, &join.to_vec());
+            let result = server.post(&agent_uri, &signed_join.to_vec());
             assert_eq!(result, Ok(()));
         }
-        (agent_uri, space_data)
+        (secret_key, agent_uri, space_data)
     }
 
     #[test]
@@ -981,8 +1033,9 @@ pub mod tests {
         let sim2h_uri = sim2h.bound_uri.clone().expect("should have bound");
 
         // set up two other agents on the memory-network
-        let (agent1_uri, space_data1) = test_setup_agent(netname, &sim2h_uri, "agent1");
-        let (agent2_uri, space_data2) = test_setup_agent(netname, &sim2h_uri, "agent2");
+        let (mut secret_key1, agent1_uri, space_data1) =
+            test_setup_agent(netname, &sim2h_uri, "agent1");
+        let (_, agent2_uri, space_data2) = test_setup_agent(netname, &sim2h_uri, "agent2");
 
         let _result = sim2h.process();
         assert_eq!(
@@ -995,8 +1048,8 @@ pub mod tests {
         );
 
         // now send a direct message from agent1 through sim2h which should arrive at agent2
-        let data = make_test_dm_data_with(
-            space_data1.agent_id,
+        let dm_data = make_test_dm_data_with(
+            space_data1.agent_id.clone(),
             space_data2.agent_id,
             "come here watson",
         );
@@ -1005,13 +1058,15 @@ pub mod tests {
             let mut verse = get_memory_verse();
             verse.get_network(netname)
         };
-        let message: Opaque = make_test_dm_message_with(data).into();
+
+        let message = make_test_dm_message_with(dm_data.clone());
+        let signed_message: Opaque = make_signed(&mut secret_key1, &space_data1, message).into();
         {
             let mut net = network.lock().unwrap();
             let server = net
                 .get_server(&sim2h_uri)
                 .expect("there should be a server for to_uri");
-            let result = server.post(&agent1_uri, &message.to_vec());
+            let result = server.post(&agent1_uri, &signed_message.to_vec());
             assert_eq!(result, Ok(()));
         }
         let _result = sim2h.process();
@@ -1025,7 +1080,7 @@ pub mod tests {
                 assert!(did_work);
                 let dm = &events[3];
                 assert_eq!(
-                   "ReceivedData(Lib3hUri(\"mem://addr_1/\"), \"{\\\"Lib3hToClient\\\":{\\\"HandleSendDirectMessage\\\":{\\\"space_address\\\":\\\"fake_space_address\\\",\\\"request_id\\\":\\\"\\\",\\\"to_agent_id\\\":\\\"agent2\\\",\\\"from_agent_id\\\":\\\"agent1\\\",\\\"content\\\":\\\"Y29tZSBoZXJlIHdhdHNvbg==\\\"}}}\")",
+                    "ReceivedData(Lib3hUri(\"mem://addr_1/\"), \"{\\\"Lib3hToClient\\\":{\\\"HandleSendDirectMessage\\\":{\\\"space_address\\\":\\\"fake_space_address\\\",\\\"request_id\\\":\\\"\\\",\\\"to_agent_id\\\":\\\"HcScIYA59KD3q734m3YThPPaB594afvuyvRyYzK86575g6Pe66GCA4AJF3EGroa\\\",\\\"from_agent_id\\\":\\\"HcSCI4uqnzxGv4bqbbBdaVrg5V4F7sxr7Fat7UaAYx9giwadHij6VeXHtjt6dsi\\\",\\\"content\\\":\\\"Y29tZSBoZXJlIHdhdHNvbg==\\\"}}}\")",
                     format!("{:?}", dm))
             } else {
                 assert!(false)
@@ -1040,11 +1095,12 @@ pub mod tests {
         let mut sim2h = make_test_sim2h_memnet(netname);
         let _result = sim2h.process();
         let sim2h_uri = sim2h.bound_uri.clone().expect("should have bound");
-        let (agent_uri, data) = test_setup_agent(netname, &sim2h_uri, "agent");
+        let (mut secret_key, agent_uri, space_data) =
+            test_setup_agent(netname, &sim2h_uri, "agent");
         let _result = sim2h.process();
 
         assert_eq!(
-            sim2h.lookup_joined(&data.space_address, &data.agent_id),
+            sim2h.lookup_joined(&space_data.space_address, &space_data.agent_id),
             Some(agent_uri.clone())
         );
 
@@ -1062,7 +1118,7 @@ pub mod tests {
         let _result = sim2h.process();
 
         assert_eq!(
-            sim2h.lookup_joined(&data.space_address, &data.agent_id),
+            sim2h.lookup_joined(&space_data.space_address, &space_data.agent_id),
             None
         );
 
@@ -1074,10 +1130,15 @@ pub mod tests {
                 .expect("there should be a server for sim2h_uri");
             server.request_connect(&agent_uri).expect("can connect");
 
-            let data =
-                make_test_dm_data_with(data.agent_id.clone(), data.agent_id, "come here watson");
-            let message: Opaque = make_test_dm_message_with(data).into();
-            let result = server.post(&agent_uri, &message.to_vec());
+            let dm_data = make_test_dm_data_with(
+                space_data.agent_id.clone(),
+                space_data.agent_id.clone(),
+                "come here watson",
+            );
+
+            let message = make_test_dm_message_with(dm_data.clone());
+            let signed_message: Opaque = make_signed(&mut secret_key, &space_data, message).into();
+            let result = server.post(&agent_uri, &signed_message.to_vec());
             assert_eq!(result, Ok(()));
         }
         let _result = sim2h.process();

--- a/crates/sim2h/src/wire_message.rs
+++ b/crates/sim2h/src/wire_message.rs
@@ -1,4 +1,5 @@
 //! encapsulates lib3h ghostmessage for sim2h including security challenge
+use crate::error::Sim2hError;
 use lib3h_protocol::data_types::Opaque;
 use lib3h_protocol::protocol::*;
 use std::convert::TryFrom;
@@ -135,6 +136,12 @@ impl From<&str> for WireError {
 impl From<String> for WireError {
     fn from(err: String) -> Self {
         WireError::Other(err)
+    }
+}
+
+impl From<WireError> for Sim2hError {
+    fn from(err: WireError) -> Sim2hError {
+        format!("{:?}", err).into()
     }
 }
 

--- a/crates/sim2h/src/wire_message.rs
+++ b/crates/sim2h/src/wire_message.rs
@@ -111,6 +111,13 @@ impl From<WireMessage> for Opaque {
     }
 }
 
+impl From<WireMessage> for String {
+    fn from(message: WireMessage) -> String {
+        serde_json::to_string(&message)
+            .expect("wiremessage should serialize")
+    }
+}
+
 impl TryFrom<Opaque> for WireMessage {
     type Error = WireError;
     fn try_from(message: Opaque) -> Result<Self, Self::Error> {

--- a/crates/sim2h_server/src/main.rs
+++ b/crates/sim2h_server/src/main.rs
@@ -1,5 +1,6 @@
 extern crate structopt;
 
+use lib3h::transport::websocket::tls::TlsCertificate;
 use lib3h::transport::{
     protocol::DynTransportActor,
     websocket::{actor::GhostTransportWebsocket, tls::TlsConfig},
@@ -9,7 +10,6 @@ use log::error;
 use sim2h::Sim2h;
 use std::process::exit;
 use structopt::StructOpt;
-use lib3h::transport::websocket::tls::TlsCertificate;
 
 #[derive(StructOpt)]
 struct Cli {


### PR DESCRIPTION
Adds SignedWireMessage and crypto to verify the signature.

- [x] Constructor for use by core.
- [x] Followup: send messages from core using this
- [x] confirm that signer is also the same agent as specified in the content on a per message type bases in handle_messages()